### PR TITLE
Update to eliminate deprecation warnings; plugin API changed c. 2016 …

### DIFF
--- a/src/js/background_scripts/sites/youtube.com.js
+++ b/src/js/background_scripts/sites/youtube.com.js
@@ -8,7 +8,7 @@
             super(player);
 
             console.log("youtube");
-            this.pluginURL = "plugin://plugin.video.youtube/?action=play_video&videoid=%s";
+            this.pluginURL = "plugin://plugin.video.youtube/play/?video_id=%s";
             this.gService = new GService();
 
             contextMenu.addSite("youtube.com", this, ["*://www.youtube.com/*v=*"], ["*://www.youtube.com/*list=*"]);


### PR DESCRIPTION
This is a minor update to eliminate a deprecation warning; the plugin.video.youtube API was updated several years ago and will eventually drop support for the form that youtube-to-XBMC/kassi is currently using.

The new format for the calls is supported in kodi Isengard (released c. 2015-2016) and later.

…https://github.com/anxdpanic/plugin.video.youtube/blob/master/resources/lib/youtube_plugin/youtube/helper/yt_old_actions.py